### PR TITLE
Fix fetch error logs

### DIFF
--- a/packages/klevu-core/src/connection/fetch.ts
+++ b/packages/klevu-core/src/connection/fetch.ts
@@ -1,20 +1,33 @@
 import { KlevuConfig } from "../config.js"
 
-export async function get<T>(url: string): Promise<T> {
+export async function get<T>(
+  url: string,
+  ignoreResult = false
+): Promise<T | undefined> {
   if (KlevuConfig.default.axios) {
     return (await KlevuConfig.default.axios.get<T>(url)).data
   }
 
-  return await fetch(url, {
+  const res = await fetch(url, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
     },
-  }).then((res) => res.json())
+  })
+
+  if (ignoreResult) {
+    return undefined
+  }
+
+  return (await res.json()) as T
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function post<T>(url: string, data: any): Promise<T> {
+export async function post<T>(
+  url: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any,
+  ignoreResult = false
+): Promise<T | undefined> {
   if (KlevuConfig.default.axios) {
     return await KlevuConfig.default.axios
       .post<T>(url, data, {
@@ -25,11 +38,17 @@ export async function post<T>(url: string, data: any): Promise<T> {
       .then((res) => res.data)
   }
 
-  return await fetch(url, {
+  const res = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(data),
-  }).then((res) => res.json())
+  })
+
+  if (ignoreResult) {
+    return undefined
+  }
+
+  return (await res.json()) as T
 }

--- a/packages/klevu-core/src/connection/klevuFetch.ts
+++ b/packages/klevu-core/src/connection/klevuFetch.ts
@@ -58,10 +58,16 @@ export async function KlevuFetch(
   if (cached) {
     response = cached
   } else {
-    response = await post<KlevuApiRawResponse>(
+    const res = await post<KlevuApiRawResponse>(
       withOverride?.configOverride?.url ?? KlevuConfig.default.url,
       payload
     )
+
+    if (!res) {
+      throw new Error("Couldn't fetch data")
+    }
+
+    response = res
     cache.cache(payload, response)
   }
 

--- a/packages/klevu-core/src/events/eventRequests.ts
+++ b/packages/klevu-core/src/events/eventRequests.ts
@@ -32,7 +32,7 @@ export async function KlevuEventV1Search(event: V1SearchEvent) {
   const url = `${
     KlevuConfig.default.eventsApiV1Url
   }n-search/search${objectToUrlParams(event)}`
-  return get(url)
+  return get(url, true)
 }
 
 export type V1ProductTrackingEvent = {
@@ -87,7 +87,7 @@ export async function KlevuEventV1ProductTracking(
   const url = `${
     KlevuConfig.default.eventsApiV1Url
   }productTracking${objectToUrlParams(event)}`
-  return get(url)
+  return get(url, true)
 }
 
 export type V1CheckedOutProductsEvent = {
@@ -143,7 +143,7 @@ export async function KlevuEventV1CheckedOutProducts(
   const url = `${
     KlevuConfig.default.eventsApiV1Url
   }productTracking${objectToUrlParams(event)}`
-  return get(url)
+  return get(url, true)
 }
 
 export type KlevuV1CategoryProductsView = {
@@ -185,7 +185,7 @@ export async function KlevuEventV1CategoryView(
   const url = `${
     KlevuConfig.default.eventsApiV1Url
   }categoryProductViewTracking${objectToUrlParams(event)}`
-  return get(url)
+  return get(url, true)
 }
 
 export type KlevuV1CategoryProductsClick = {
@@ -250,7 +250,7 @@ export async function KlevuEventV1CategoryProductClick(
   const url = `${
     KlevuConfig.default.eventsApiV1Url
   }categoryProductClickTracking${objectToUrlParams(event)}`
-  return get(url)
+  return get(url, true)
 }
 
 function objectToUrlParams(event: object) {
@@ -351,5 +351,5 @@ type KlevuEventV2 = {
 }
 
 export async function KlevuEventV2(data: KlevuEventV2[]) {
-  return await post(KlevuConfig.default.eventsApiV2Url, data)
+  return await post(KlevuConfig.default.eventsApiV2Url, data, true)
 }

--- a/packages/klevu-core/src/queries/kmcRecommendation/kmcRecommendation.ts
+++ b/packages/klevu-core/src/queries/kmcRecommendation/kmcRecommendation.ts
@@ -143,6 +143,10 @@ export async function kmcRecommendation(
     `https://config-cdn.ksearchnet.com/recommendations/${KlevuConfig.default.apiKey}/settings/${recommendationId}`
   )
 
+  if (!kmcConfig) {
+    throw new Error("Couldn't fetch KMC config")
+  }
+
   const configOverride = new KlevuConfig({
     apiKey: KlevuConfig.default.apiKey,
     url: `https://${kmcConfig.search.basePath}`,

--- a/packages/klevu-core/tsconfig-base.json
+++ b/packages/klevu-core/tsconfig-base.json
@@ -14,5 +14,5 @@
   "watchOptions": {
     "excludeDirectories": ["**/node_modules", "dist"]
   },
-  "exclude": ["*/**/*.test.ts"]
+  "exclude": ["*/**/*.test.ts", "**/node_modules", "dist"]
 }


### PR DESCRIPTION
When analytical calls was returning xml fetch was trying to read it as json.
Now result can be ignored from request.