### PR TITLE
Remove unsafe strip tags function

### DIFF
--- a/packages/klevu-core/src/utils/cleanSearchQuery.ts
+++ b/packages/klevu-core/src/utils/cleanSearchQuery.ts
@@ -16,7 +16,3 @@ export function cleanSearchQuery(term: string): string {
       .toLocaleLowerCase()
   )
 }
-
-export function stripTags(html: string): string {
-  return html.replace(/<[^>]*>?/gm, "")
-}


### PR DESCRIPTION
Only security issue in the project is the unsafe strip tags code. Remove it as it is not used in anywhere.