### PR TITLE
Implement getPage helper. Closes #161

### DIFF
--- a/packages/klevu-core/src/connection/klevuFetch.ts
+++ b/packages/klevu-core/src/connection/klevuFetch.ts
@@ -129,6 +129,7 @@ function KlevuQueriesById(
     ...res,
     ...FetchResultEvents(res, func),
     next: fetchNextPage(response, func),
+    getPage: fetchNextPage(response, func, true),
     functionParams: func.params,
     annotationsById: (productId: string, languageCode: string) =>
       getAnnotationsForProduct(res, productId, languageCode),
@@ -172,6 +173,13 @@ async function cleanAndProcessFunctions(
   }
 }
 
+/**
+ * Removes list filters from query
+ *
+ * @param f
+ * @param prevQueryResult
+ * @returns
+ */
 export function removeListFilters(
   f: KlevuFetchFunctionReturnValue,
   prevQueryResult: KlevuQueryResult

--- a/packages/klevu-core/src/connection/resultHelpers/fetchNextPage.ts
+++ b/packages/klevu-core/src/connection/resultHelpers/fetchNextPage.ts
@@ -11,7 +11,8 @@ import { KlevuFetch, removeListFilters } from "../klevuFetch.js"
 
 export function fetchNextPage(
   response: KlevuApiRawResponse,
-  func: KlevuFetchFunctionReturnValue
+  func: KlevuFetchFunctionReturnValue,
+  ignoreLastPageUndefined = false
 ) {
   if (!func.queries) {
     return undefined
@@ -35,8 +36,9 @@ export function fetchNextPage(
 
   // no more pages
   if (
+    !ignoreLastPageUndefined &&
     prevQueryResponse.meta.totalResultsFound <=
-    prevQueryResponse.meta.offset + prevQueryResponse.meta.noOfResults
+      prevQueryResponse.meta.offset + prevQueryResponse.meta.noOfResults
   ) {
     return undefined
   }
@@ -46,8 +48,13 @@ export function fetchNextPage(
       prevQuery.settings = {}
     }
 
-    prevQuery.settings.offset =
-      prevQueryResponse.meta.noOfResults + prevQueryResponse.meta.offset
+    if (override?.pageIndex !== undefined) {
+      prevQuery.settings.offset =
+        prevQueryResponse.meta.noOfResults * override.pageIndex
+    } else {
+      prevQuery.settings.offset =
+        prevQueryResponse.meta.noOfResults + prevQueryResponse.meta.offset
+    }
     prevQuery.settings.limit = override?.limit ?? prevQuery.settings?.limit ?? 5
 
     // existance of prevQuery has checked in function before

--- a/packages/klevu-core/src/models/KlevuFetchResponse.ts
+++ b/packages/klevu-core/src/models/KlevuFetchResponse.ts
@@ -18,6 +18,11 @@ export type KlevuNextFunc = (override?: {
    * Filter manager to apply for next function
    */
   filterManager?: FilterManager
+
+  /**
+   * Use page index to load certain page instead of next available. 0 is first page
+   */
+  pageIndex?: number
 }) => Promise<KlevuFetchResponse>
 
 /**
@@ -25,8 +30,17 @@ export type KlevuNextFunc = (override?: {
  */
 export type KlevuFetchQueryResult = KlevuQueryResult &
   KlevuResultEvent & {
-    /** If there are multiple pages of results next function is defined. Calling this function will result new result  */
+    /**
+     * If there are multiple pages of results next function is defined. Calling this function will result new result
+     *
+     * @deprecated use `getPage()` function instead of next
+     */
     next?: KlevuNextFunc
+
+    /**
+     * Same as next function, but it is always returned even on the last page. Without parameters returns next page.
+     */
+    getPage?: KlevuNextFunc
     /**
      * All parameters defined in that query function
      */


### PR DESCRIPTION
Implements new `getPage()` helper. It's same as `next()`, but it returns even though on the last page.

`getPage()` works exactly the same as `next()` without parameters. Due to that I have set `next()` deprecated function.

Biggest change is that both deprecated `next()` and `getPage()` has new parameter `pageIndex`. This allows to request certain page instead of next one. Not providing this pageIndex will automatically go to next page.