### PR TITLE
Add possibility to override analytical requests parameter on modifiers

### DIFF
--- a/packages/klevu-core/src/modifiers/sendMerchandisingViewEvent/sendMerchandisingViewEvent.ts
+++ b/packages/klevu-core/src/modifiers/sendMerchandisingViewEvent/sendMerchandisingViewEvent.ts
@@ -1,6 +1,7 @@
 import { KlevuFetchModifer } from "../index.js"
 import { KlevuEvents } from "../../events/index.js"
 import { extractActiveFilters } from "../../utils/extractActiveFilters.js"
+import { KlevuV1CategoryProductsView } from "../../events/eventRequests.js"
 
 /**
  * This modifier should be used with merchandising query. It sends
@@ -10,7 +11,10 @@ import { extractActiveFilters } from "../../utils/extractActiveFilters.js"
  * @param title Title of the category page viewed
  * @returns
  */
-export function sendMerchandisingViewEvent(title: string): KlevuFetchModifer {
+export function sendMerchandisingViewEvent(
+  title: string,
+  override?: Partial<KlevuV1CategoryProductsView>
+): KlevuFetchModifer {
   return {
     klevuModifierId: "sendMerchandisingViewEvent",
     onResult: (res, f) => {
@@ -44,6 +48,7 @@ export function sendMerchandisingViewEvent(title: string): KlevuFetchModifer {
         abTestId: abtest?.abTestId,
         abTestVariantId: abtest?.abTestVariantId,
         activeFilters: extractActiveFilters(queryResult),
+        override,
       })
 
       return res

--- a/packages/klevu-core/src/modifiers/sendRecommendationViewEvent/sendRecommendationViewEvent.ts
+++ b/packages/klevu-core/src/modifiers/sendRecommendationViewEvent/sendRecommendationViewEvent.ts
@@ -4,6 +4,7 @@ import {
   RecommendationViewEventMetaData,
 } from "../../events/index.js"
 import { KlevuTypeOfRequest } from "../../models/KlevuTypeOfRequest.js"
+import { KlevuEventV2Data } from "../../events/eventRequests.js"
 
 const recommendationTypeOfRequests: KlevuTypeOfRequest[] = [
   KlevuTypeOfRequest.AlsoBought,
@@ -22,7 +23,8 @@ const recommendationTypeOfRequests: KlevuTypeOfRequest[] = [
  */
 export function sendRecommendationViewEvent(
   title: string,
-  eventData?: RecommendationViewEventMetaData
+  eventData?: RecommendationViewEventMetaData,
+  override?: Partial<KlevuEventV2Data>
 ): KlevuFetchModifer {
   return {
     klevuModifierId: "sendMerchandisingViewEvent",
@@ -57,6 +59,7 @@ export function sendRecommendationViewEvent(
             title,
           },
           products,
+          override,
         })
         return res
       }

--- a/packages/klevu-core/src/modifiers/sendSearchEvent/sendSearchEvent.ts
+++ b/packages/klevu-core/src/modifiers/sendSearchEvent/sendSearchEvent.ts
@@ -1,5 +1,6 @@
 import { KlevuFetchModifer } from "../index.js"
 import { KlevuEvents } from "../../events/index.js"
+import { V1SearchEvent } from "../../events/eventRequests.js"
 
 /**
  * This modifier should be used in the case when user hits enter (or presses button) to see
@@ -8,7 +9,9 @@ import { KlevuEvents } from "../../events/index.js"
  * @category Modifier
  * @returns
  */
-export function sendSearchEvent(): KlevuFetchModifer {
+export function sendSearchEvent(
+  override?: Partial<V1SearchEvent>
+): KlevuFetchModifer {
   return {
     klevuModifierId: "sendSearchEvent",
     onResult: (res, f) => {
@@ -31,6 +34,7 @@ export function sendSearchEvent(): KlevuFetchModifer {
         term,
         totalResults: meta.totalResultsFound,
         typeOfSearch: meta.typeOfSearch,
+        override,
       })
 
       return res

--- a/packages/klevu-core/src/modifiers/sendSearchEvent/sendSearchEvents.test.ts
+++ b/packages/klevu-core/src/modifiers/sendSearchEvent/sendSearchEvents.test.ts
@@ -1,6 +1,7 @@
 import { KlevuConfig, KlevuFetch, search } from "../../index.js"
 import { sendSearchEvent } from "./sendSearchEvent.js"
 import axios from "axios"
+import { jest } from "@jest/globals"
 
 beforeEach(() => {
   KlevuConfig.init({
@@ -23,4 +24,33 @@ test("Sending search event", async () => {
   )
 
   expect(result.queriesById("test")).toBeDefined()
+})
+
+test("Override IP with custom data", async () => {
+  const getSpySuccess = jest
+    .spyOn(KlevuConfig.default!.axios!, "get")
+    .mockImplementation(() => {
+      return new Promise((resolve, reject) => {
+        return resolve({
+          data: {},
+        })
+      })
+    })
+
+  await KlevuFetch(
+    search(
+      "hoodies",
+      {
+        id: "test",
+      },
+      sendSearchEvent({
+        klevu_shopperIP: "1.2.3.4",
+      })
+    )
+  )
+
+  expect(getSpySuccess).toHaveBeenCalledTimes(1)
+  expect(getSpySuccess).toHaveBeenCalledWith(
+    expect.stringContaining("klevu_shopperIP=1.2.3.4")
+  )
 })


### PR DESCRIPTION
Add override parameter to `sendSearchEvent()`, `sendRecommendationViewEvent()` and `sendMerchandisingViewEvent()` functions.