### PR TITLE
Improve query object to fetch query params more cleaner way

### DIFF
--- a/examples/vanillajs/index.html
+++ b/examples/vanillajs/index.html
@@ -9,7 +9,8 @@
     <ul>
       <li><a href="quicksearch.html">Search</a></li>
       <li><a href="merchandising.html">Merchandising</a></li>
-      <li><a href="recommendations.html">Recomenndations</a></li>
+      <li><a href="recommendations.html">Recommendations</a></li>
+      <li><a href="recommendationskmc.html">KMC recommendations</a></li>
     </ul>
   </body>
 </html>

--- a/examples/vanillajs/package-lock.json
+++ b/examples/vanillajs/package-lock.json
@@ -16,22 +16,23 @@
       }
     },
     "../../packages/klevu-core": {
-      "version": "2.0.9",
+      "name": "@klevu/core",
+      "version": "3.0.4",
       "license": "MIT",
       "devDependencies": {
-        "@types/jest": "^27.5.2",
-        "@typescript-eslint/eslint-plugin": "^5.10.2",
-        "@typescript-eslint/parser": "^5.10.2",
-        "axios": "^1.1.3",
-        "eslint": "^8.8.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-import": "^2.26.0",
-        "jest": "^27.5.0",
-        "ts-jest": "^27.1.3",
-        "ts-node": "^10.4.0",
-        "typedoc": "^0.23.16",
-        "typedoc-plugin-markdown": "^3.13.6",
-        "typescript": "^4.5.5"
+        "@types/jest": "^29.5.2",
+        "@typescript-eslint/eslint-plugin": "^5.61.0",
+        "@typescript-eslint/parser": "^5.61.0",
+        "axios": "^1.4.0",
+        "eslint": "^8.44.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.27.5",
+        "jest": "^29.6.1",
+        "ts-jest": "^29.1.1",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.24.8",
+        "typedoc-plugin-markdown": "^3.15.3",
+        "typescript": "^5.1.6"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -640,19 +641,19 @@
     "@klevu/core": {
       "version": "file:../../packages/klevu-core",
       "requires": {
-        "@types/jest": "^27.5.2",
-        "@typescript-eslint/eslint-plugin": "^5.10.2",
-        "@typescript-eslint/parser": "^5.10.2",
-        "axios": "^1.1.3",
-        "eslint": "^8.8.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-import": "^2.26.0",
-        "jest": "^27.5.0",
-        "ts-jest": "^27.1.3",
-        "ts-node": "^10.4.0",
-        "typedoc": "^0.23.16",
-        "typedoc-plugin-markdown": "^3.13.6",
-        "typescript": "^4.5.5"
+        "@types/jest": "^29.5.2",
+        "@typescript-eslint/eslint-plugin": "^5.61.0",
+        "@typescript-eslint/parser": "^5.61.0",
+        "axios": "^1.4.0",
+        "eslint": "^8.44.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.27.5",
+        "jest": "^29.6.1",
+        "ts-jest": "^29.1.1",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.24.8",
+        "typedoc-plugin-markdown": "^3.15.3",
+        "typescript": "^5.1.6"
       }
     },
     "esbuild": {

--- a/examples/vanillajs/recommendationskmc.html
+++ b/examples/vanillajs/recommendationskmc.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Vanilla JS KMC recommendation example</title>
+  </head>
+  <body>
+    <pre id="output"></pre>
+
+    <script src="./init.ts" type="module"></script>
+    <script src="./recommendationskmc.ts" type="module"></script>
+  </body>
+</html>

--- a/examples/vanillajs/recommendationskmc.ts
+++ b/examples/vanillajs/recommendationskmc.ts
@@ -1,0 +1,15 @@
+import { KlevuFetch, kmcRecommendation } from "@klevu/core"
+import { printToOutput } from "./utils"
+
+async function load() {
+  const result = await KlevuFetch(
+    kmcRecommendation("k-b1c018f7-ee85-45c0-b65f-b9556f7dc15d")
+  )
+
+  const query = result.queriesById("kmcrecommendation")
+
+  console.log(query.getQueryParameters())
+  printToOutput(query.records)
+}
+
+load()

--- a/packages/klevu-core/src/connection/responseObject.ts
+++ b/packages/klevu-core/src/connection/responseObject.ts
@@ -2,6 +2,10 @@ import { KlevuApiRawResponse } from "../models/KlevuApiRawResponse.js"
 import { KlevuFetchFunctionReturnValue } from "../queries/index.js"
 import { KlevuResponseQueryObject } from "./responseQueryObject.js"
 
+/**
+ * This class is used to access the response data from Klevu API
+ * It builds up the state of the result and it can be used to do various things with the data
+ */
 export class KlevuResponseObject {
   apiResponse: KlevuApiRawResponse
   #functions: KlevuFetchFunctionReturnValue[]
@@ -25,6 +29,12 @@ export class KlevuResponseObject {
     }
   }
 
+  /**
+   * Get suggestions by id
+   *
+   * @param id
+   * @returns
+   */
   suggestionsById(id: string) {
     return this.apiResponse.suggestionResults?.find((q) => q.id === id)
   }
@@ -40,6 +50,11 @@ export class KlevuResponseObject {
     }
   }
 
+  /**
+   * Get query results by id
+   * @param id query id used
+   * @returns
+   */
   queriesById(id: string) {
     if (!this.#queryObjects[id]) {
       throw new Error(`Query with id ${id} not found`)
@@ -47,6 +62,12 @@ export class KlevuResponseObject {
     return this.#queryObjects[id]
   }
 
+  /**
+   * Check if query exists. This should be used as queriesById can throw an error
+   *
+   * @param id query id used
+   * @returns
+   */
   queryExists(id: string) {
     return !!this.#queryObjects[id]
   }

--- a/packages/klevu-core/src/connection/responseQueryObject.ts
+++ b/packages/klevu-core/src/connection/responseQueryObject.ts
@@ -333,4 +333,13 @@ export class KlevuResponseQueryObject {
   annotationsById(productId: string, languageCode: string) {
     return getAnnotationsForProduct(this.query, productId, languageCode)
   }
+
+  /**
+   * @returns List of params used in the query and the metadata that was generated during
+   * the query. This is useful for example to fetching KMC metadata that was received
+   * for recommendations query.
+   */
+  getQueryParameters() {
+    return this.func.params
+  }
 }


### PR DESCRIPTION
Now function parameters can be fetched from query results with `query.getQueryParameters()` method.