### PR TITLE
Add no image placeholder for the klevu-product

### DIFF
--- a/packages/klevu-ui/src/components/klevu-product/klevu-product.css
+++ b/packages/klevu-ui/src/components/klevu-product/klevu-product.css
@@ -206,6 +206,14 @@
   gap: var(--klevu-spacing-02);
 }
 
+.image.no-image {
+  color: var(--klevu-color-neutral-5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 4em;
+}
+
 @keyframes loadinggradient {
   0% {
     background-position: 0% 50%;

--- a/packages/klevu-ui/src/components/klevu-product/klevu-product.stories.ts
+++ b/packages/klevu-ui/src/components/klevu-product/klevu-product.stories.ts
@@ -3,6 +3,7 @@ import { html } from "lit-html"
 import { ifDefined } from "lit-html/directives/if-defined.js"
 import type { Meta, StoryObj } from "@storybook/web-components"
 import { KlevuProduct } from "./klevu-product"
+import { KlevuRecord } from "@klevu/core"
 export const { argTypes, parameters, description, decorators } = MDXAutoFillMeta("klevu-product")
 
 const productItem = mockProducts[0]
@@ -11,7 +12,8 @@ const productItem3 = fullMockRequest.queryResults?.[0].records[2]
 
 export const ProductItems = { productItem, productItem2, productItem3 }
 
-const productRender = (args: KlevuProduct) => html` <klevu-product
+const productRender = (args: KlevuProduct, className?: string) => html` <klevu-product
+  class=${ifDefined(className)}
   style="--klevu-product-width: 300px"
   variant=${args.variant}
   .product=${args.product}
@@ -54,6 +56,10 @@ export const SmallProduct: StoryObj<KlevuProduct> = {
 }
 
 export const CustomizedProducts: StoryObj<KlevuProduct> = {
+  args: {
+    product: productItem,
+    variant: "default",
+  },
   render: (args: KlevuProduct) => html`<div>
     <klevu-product
       style="--klevu-product-width: 300px; --klevu-product-image-aspect-ratio: 1 / 1.3"
@@ -101,5 +107,27 @@ export const LineItems: StoryObj<KlevuProduct> = {
     ${productRender({ product: productItem, variant: "line" } as any)}
     ${productRender({ product: productItem2, variant: "line" } as any)}
     ${productRender({ product: productItem3, variant: "line" } as any)}
+  `,
+}
+
+export const ProductWithoutImage: StoryObj<KlevuProduct> = {
+  render: (args: KlevuProduct) => html`
+    ${productRender(
+      {
+        variant: "default",
+        product: {
+          name: "Product without image",
+          shortDesc: "This is a product that has no image. There should be no image placeholder.",
+          price: "12345",
+          currency: "JPY",
+        } as Partial<KlevuRecord>,
+      } as any,
+      "without-image"
+    )}
+    <style>
+      klevu-product.without-image::part(product-container) {
+        border: 1px solid black;
+      }
+    </style>
   `,
 }

--- a/packages/klevu-ui/src/components/klevu-product/klevu-product.tsx
+++ b/packages/klevu-ui/src/components/klevu-product/klevu-product.tsx
@@ -165,13 +165,19 @@ export class KlevuProduct {
           <a href={settings?.generateProductUrl?.(this.product)} onClick={this.#click.bind(this)}>
             {this.hideImage ? null : (
               <slot name="image">
-                <div
-                  class="image"
-                  part="product-image"
-                  style={{
-                    backgroundImage: `url(${this.hoverImage || this.product.image})`,
-                  }}
-                ></div>
+                {this.product?.image || this.hoverImage ? (
+                  <div
+                    class="image"
+                    part="product-image"
+                    style={{
+                      backgroundImage: `url(${this.hoverImage || this.product.image})`,
+                    }}
+                  ></div>
+                ) : (
+                  <div class="image no-image" part="product-image">
+                    <klevu-icon name="image_not_supported"></klevu-icon>
+                  </div>
+                )}
               </slot>
             )}
             <slot name="info">


### PR DESCRIPTION
when there is no image available in `klevu-product` it shows a `klevu-icon` placeholder for missing image.