### PR TITLE
CORE: Add helper for getting redirects and configurable cache length

### DIFF
--- a/packages/klevu-core/src/connection/kmc.ts
+++ b/packages/klevu-core/src/connection/kmc.ts
@@ -15,9 +15,13 @@ const ONE_DAY = 86_400_000
  *
  * @category KlevuFetch
  * @param ignoreCache If true, will ignore cache and fetch data from server
+ * @param cacheLength How long to cache data in milliseconds
  * @returns
  */
-export async function KlevuKMCSettings(ignoreCache?: boolean): Promise<{
+export async function KlevuKMCSettings(
+  ignoreCache?: boolean,
+  cacheLength = ONE_DAY
+): Promise<{
   root?: KMCRootObject
   banner?: KMCBannerRootObject
   maps?: KMCMapsRootObject
@@ -25,7 +29,7 @@ export async function KlevuKMCSettings(ignoreCache?: boolean): Promise<{
   if (isBrowser() && window.localStorage && ignoreCache !== true) {
     const ts = window.localStorage.getItem(STORAGE_TS_KEY)
     const res = window.localStorage.getItem(STORAGE_KEY)
-    if (res && ts && new Date().getTime() - parseInt(ts, 10) < ONE_DAY) {
+    if (res && ts && new Date().getTime() - parseInt(ts, 10) < cacheLength) {
       return JSON.parse(res)
     }
   }

--- a/packages/klevu-core/src/connection/kmcmodels/KMCMaps.ts
+++ b/packages/klevu-core/src/connection/kmcmodels/KMCMaps.ts
@@ -1,4 +1,4 @@
-interface KlevuKeywordUrlMap {
+export interface KlevuKeywordUrlMap {
   keywords: string[]
   url: string
 }

--- a/packages/klevu-core/src/connection/resultHelpers/getRedirects.test.ts
+++ b/packages/klevu-core/src/connection/resultHelpers/getRedirects.test.ts
@@ -1,0 +1,44 @@
+import axios from "axios"
+import {
+  KlevuConfig,
+  KlevuFetch,
+  categoryMerchandising,
+  search,
+} from "../../index.js"
+
+beforeEach(() => {
+  KlevuConfig.init({
+    url: "https://eucs29v2.ksearchnet.com/cs/v2/search",
+    apiKey: "klevu-164651914788114877",
+    axios,
+  })
+})
+
+test("Searching test string should have redirects", async () => {
+  const result = await KlevuFetch(
+    search("test-do-not-remove", {
+      id: "test",
+    })
+  )
+
+  const test = await result.queriesById("test")
+
+  expect(test.getRedirects).toBeDefined()
+
+  const redirects = await test.getRedirects?.()
+  expect(redirects?.length).toBe(1)
+
+  expect(redirects?.[0].url).toContain("www.klevu.com")
+})
+
+test("Category merchandising test string should not have redirects", async () => {
+  const result = await KlevuFetch(
+    categoryMerchandising("women", {
+      id: "test",
+    })
+  )
+
+  const test = await result.queriesById("test")
+
+  expect(test.getRedirects).not.toBeDefined()
+})

--- a/packages/klevu-core/src/connection/resultHelpers/getRedirects.ts
+++ b/packages/klevu-core/src/connection/resultHelpers/getRedirects.ts
@@ -1,0 +1,16 @@
+import { KlevuKMCSettings } from "../kmc.js"
+import { KlevuKeywordUrlMap } from "../kmcmodels/KMCMaps.js"
+
+export async function getRedirects(
+  term: string
+): Promise<KlevuKeywordUrlMap[]> {
+  const settings = await KlevuKMCSettings()
+
+  if (!settings.maps) {
+    return []
+  }
+
+  return settings.maps.klevu_keywordUrlMap.filter((map) =>
+    map.keywords.some((k) => k === term)
+  )
+}


### PR DESCRIPTION
- Adds a helper function feature to search results which can be used to fetch redirects that match the search
- Adds configuration for KMCSetting so that caching length can be adjusted from 24 hours.