### PR TITLE
CORE: Add parameter to config init to prevent click tracking

### DIFF
--- a/packages/klevu-core/src/config.ts
+++ b/packages/klevu-core/src/config.ts
@@ -35,6 +35,11 @@ type KlevuConfiguration = {
    *
    */
   axios?: AxiosStatic
+
+  /**
+   * Prevent clicks being tracked in memory or stored in local storage. This will break personalisation and recommendations.
+   */
+  disableClickTrackStoring?: boolean
 }
 
 export class KlevuConfig {
@@ -47,6 +52,7 @@ export class KlevuConfig {
   eventsApiV2Url = "https://stats.ksearchnet.com/analytics/collect"
   axios?: AxiosInstance
   moiApiUrl = "https://moi-ai.ksearchnet.com/"
+  disableClickTracking = false
 
   constructor(config: KlevuConfiguration) {
     this.apiKey = config.apiKey
@@ -60,6 +66,8 @@ export class KlevuConfig {
     if (config.axios) {
       this.axios = config.axios.create()
     }
+
+    this.disableClickTracking = config.disableClickTrackStoring ?? false
   }
 
   static init(config: KlevuConfiguration) {

--- a/packages/klevu-core/src/store/lastClickedProducts.test.ts
+++ b/packages/klevu-core/src/store/lastClickedProducts.test.ts
@@ -1,5 +1,14 @@
+import { KlevuConfig } from "../index.js"
 import { KlevuRecord } from "../models/KlevuRecord.js"
 import { KlevuLastClickedProducts } from "./lastClickedProducts.js"
+
+beforeEach(() => {
+  KlevuConfig.init({
+    url: "https://eucs23v2.ksearchnet.com/cs/v2/search",
+    apiKey: "klevu-160320037354512854",
+    disableClickTrackStoring: false,
+  })
+})
 
 test("Product is added last clicks", () => {
   KlevuLastClickedProducts.click("1", {
@@ -46,4 +55,18 @@ test("Cache should work", () => {
   expect(
     KlevuLastClickedProducts.getCategoryPersonalisationIds("foo").length
   ).toBe(3)
+})
+
+test("Disabled click tracking should return empty array", () => {
+  KlevuConfig.getDefault().disableClickTracking = true
+
+  KlevuLastClickedProducts.click("4", {
+    id: "4",
+    name: "product 4",
+  } as KlevuRecord)
+  expect(
+    KlevuLastClickedProducts.getCategoryPersonalisationIds("foo").length
+  ).toBe(0)
+  expect(KlevuLastClickedProducts.getProducts(1).length).toBe(0)
+  expect(KlevuLastClickedProducts.getLastClickedLatestsFirst(1).length).toBe(0)
 })

--- a/packages/klevu-core/src/store/lastClickedProducts.ts
+++ b/packages/klevu-core/src/store/lastClickedProducts.ts
@@ -2,6 +2,7 @@ import { notEmpty } from "../utils/notEmpty.js"
 import { KlevuRecord } from "../models/KlevuRecord.js"
 import { isBrowser } from "../utils/isBrowser.js"
 import { KlevuDomEvents } from "../events/KlevuDomEvents.js"
+import { KlevuConfig } from "../config.js"
 
 const ONE_HOUR = 36000000
 const STORAGE_KEY = "klevu-last-clicks"
@@ -24,6 +25,9 @@ class LastClickedProducts {
   }> = []
 
   private save() {
+    if (KlevuConfig.getDefault().disableClickTracking) {
+      return
+    }
     if (isBrowser() && window.localStorage) {
       window.localStorage.setItem(STORAGE_KEY, JSON.stringify(this.clicks))
     }
@@ -48,6 +52,10 @@ class LastClickedProducts {
    * @param productId
    */
   click(productId: string, product?: Partial<KlevuRecord>) {
+    if (KlevuConfig.getDefault().disableClickTracking) {
+      return
+    }
+
     this.clicks.push({
       ts: new Date(),
       id: productId,
@@ -75,6 +83,11 @@ class LastClickedProducts {
    * @returns
    */
   getLastClickedLatestsFirst(n = 10): string[] {
+    if (KlevuConfig.getDefault().disableClickTracking) {
+      console.warn("Click tracking is disabled. Returning empty array.")
+      return []
+    }
+
     return Array.from(this.clicks.map((i) => i.id))
       .reverse()
       .slice(0, n)
@@ -87,6 +100,11 @@ class LastClickedProducts {
    * @returns
    */
   getProducts(n = 10) {
+    if (KlevuConfig.getDefault().disableClickTracking) {
+      console.warn("Click tracking is disabled. Returning empty array.")
+      return []
+    }
+
     return Array.from(this.clicks.map((i) => i.product).filter(notEmpty))
       .reverse()
       .slice(0, n)
@@ -99,6 +117,11 @@ class LastClickedProducts {
    * @returns
    */
   getCategoryPersonalisationIds(categoryPath: string): string[] {
+    if (KlevuConfig.getDefault().disableClickTracking) {
+      console.warn("Click tracking is disabled. Returning empty array.")
+      return []
+    }
+
     const currentClicks = this.clicks
     if (currentClicks.length < 3) {
       return []


### PR DESCRIPTION
For GDPR reasons it sometimes it is required to disable all kind of tracking even in the memory level.