### PR TITLE
CORE & UI: Add support for adding Facets and Pagination to URL

### DIFF
--- a/examples/vanillajs-klevu-ui/index.html
+++ b/examples/vanillajs-klevu-ui/index.html
@@ -33,9 +33,10 @@
       </nav>
       <section>
         <klevu-merchandising
-          category="Jeans & Trousers"
-          category-title="Jeans and trousers"
+          category="Products"
+          category-title="All products"
           use-pagination
+          auto-update-url
         ></klevu-merchandising>
       </section>
     </klevu-init>

--- a/examples/vanillajs-klevu-ui/package-lock.json
+++ b/examples/vanillajs-klevu-ui/package-lock.json
@@ -20,6 +20,7 @@
       "extraneous": true
     },
     "../../packages/klevu-core": {
+      "name": "@klevu/core",
       "version": "4.0.2",
       "license": "MIT",
       "devDependencies": {
@@ -39,11 +40,12 @@
       }
     },
     "../../packages/klevu-ui": {
-      "version": "0.10.2",
+      "name": "@klevu/ui",
+      "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.5.3",
-        "@klevu/core": "4.0.1",
+        "@klevu/core": "file:../klevu-core",
         "@stencil/core": "^4.4.0",
         "axios": "^1.5.1",
         "lit-html": "^2.8.0",
@@ -877,7 +879,7 @@
         "@babel/preset-typescript": "^7.23.0",
         "@floating-ui/dom": "^1.5.3",
         "@floating-ui/react": "^0.26.0",
-        "@klevu/core": "4.0.1",
+        "@klevu/core": "file:../klevu-core",
         "@stencil/core": "^4.4.0",
         "@stencil/react-output-target": "^0.5.3",
         "@stencil/vue-output-target": "^0.8.6",

--- a/packages/klevu-core/docs/modules.md
+++ b/packages/klevu-core/docs/modules.md
@@ -160,7 +160,6 @@ Global custom document events that @klevu/core sends Enumerations
 - [KlevuGetBannersByType](modules/klevugetbannersbytype.md)
 - [KlevuHydratePackedFetchResult](modules/klevuhydratepackedfetchresult.md)
 - [KlevuPackFetchResult](modules/klevupackfetchresult.md)
-- [KlevuUploadImageForSearch](modules/klevuuploadimageforsearch.md)
 - [klaviyo](modules/klaviyo.md)
 - [removeListFilters](modules/removelistfilters.md)
 - [startMoi](modules/startmoi.md)

--- a/packages/klevu-ui-vue/src/components.ts
+++ b/packages/klevu-ui-vue/src/components.ts
@@ -131,7 +131,6 @@ export const KlevuFacet = /*@__PURE__*/ defineContainer<JSX.KlevuFacet>('klevu-f
   'tAll',
   'useColorSwatch',
   'colorSwatchOverrides',
-  'shouldUpdateUrlForFacets',
   'klevuFilterSelectionUpdate'
 ]);
 
@@ -213,8 +212,7 @@ export const KlevuMerchandising = /*@__PURE__*/ defineContainer<JSX.KlevuMerchan
   'showRatings',
   'showRatingsCount',
   'usePersonalisation',
-  'shouldUpdateUrlForFacets',
-  'shouldUpdateUrlForPage',
+  'autoUpdateUrl',
   'useABTest',
   'klevuData'
 ]);
@@ -470,8 +468,7 @@ export const KlevuSearchLandingPage = /*@__PURE__*/ defineContainer<JSX.KlevuSea
   'priceInterval',
   'hidePrice',
   'showVariantsCount',
-  'shouldUpdateUrlForFacets',
-  'shouldUpdateUrlForPage',
+  'autoUpdateUrl',
   'klevuData'
 ]);
 

--- a/packages/klevu-ui-vue/src/components.ts
+++ b/packages/klevu-ui-vue/src/components.ts
@@ -131,6 +131,7 @@ export const KlevuFacet = /*@__PURE__*/ defineContainer<JSX.KlevuFacet>('klevu-f
   'tAll',
   'useColorSwatch',
   'colorSwatchOverrides',
+  'shouldUpdateUrlForFacets',
   'klevuFilterSelectionUpdate'
 ]);
 
@@ -146,6 +147,7 @@ export const KlevuFacetList = /*@__PURE__*/ defineContainer<JSX.KlevuFacetList>(
   'applyButtonText',
   'clearButtonText',
   'defaultPriceLabel',
+  'shouldUpdateUrlForFacets',
   'klevuApplyFilters'
 ]);
 
@@ -211,6 +213,8 @@ export const KlevuMerchandising = /*@__PURE__*/ defineContainer<JSX.KlevuMerchan
   'showRatings',
   'showRatingsCount',
   'usePersonalisation',
+  'shouldUpdateUrlForFacets',
+  'shouldUpdateUrlForPage',
   'useABTest',
   'klevuData'
 ]);
@@ -235,6 +239,7 @@ export const KlevuPagination = /*@__PURE__*/ defineContainer<JSX.KlevuPagination
   'min',
   'max',
   'queryResult',
+  'shouldUpdateUrlForPage',
   'klevuPaginationChange'
 ]);
 
@@ -465,6 +470,8 @@ export const KlevuSearchLandingPage = /*@__PURE__*/ defineContainer<JSX.KlevuSea
   'priceInterval',
   'hidePrice',
   'showVariantsCount',
+  'shouldUpdateUrlForFacets',
+  'shouldUpdateUrlForPage',
   'klevuData'
 ]);
 

--- a/packages/klevu-ui/package-lock.json
+++ b/packages/klevu-ui/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.5.3",
-        "@klevu/core": "4.0.1",
+        "@klevu/core": "file:../klevu-core",
         "@stencil/core": "^4.4.0",
         "axios": "^1.5.1",
         "lit-html": "^2.8.0",
@@ -57,6 +57,25 @@
         "react-simple-code-editor": "^0.13.1",
         "storybook": "^7.4.6",
         "vite": "^4.4.11"
+      }
+    },
+    "../klevu-core": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/jest": "^29.5.2",
+        "@typescript-eslint/eslint-plugin": "^5.61.0",
+        "@typescript-eslint/parser": "^5.61.0",
+        "axios": "^1.4.0",
+        "eslint": "^8.44.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-import": "^2.27.5",
+        "jest": "^29.6.1",
+        "ts-jest": "^29.1.1",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.24.8",
+        "typedoc-plugin-markdown": "^3.15.3",
+        "typescript": "^5.1.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4057,9 +4076,8 @@
       "dev": true
     },
     "node_modules/@klevu/core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@klevu/core/-/core-4.0.1.tgz",
-      "integrity": "sha512-Y8Ztdh9lH0/n6+kzI2vjiCepkL0ujn1G7Z8eHxam5aXG65X5vNdLTh4gwFn58BDD68+YCzzO7kwITGNE0vrkTQ=="
+      "resolved": "../klevu-core",
+      "link": true
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.1",

--- a/packages/klevu-ui/package.json
+++ b/packages/klevu-ui/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.5.3",
-    "@klevu/core": "4.0.1",
+    "@klevu/core": "file:../klevu-core",
     "@stencil/core": "^4.4.0",
     "axios": "^1.5.1",
     "lit-html": "^2.8.0",

--- a/packages/klevu-ui/src/components.d.ts
+++ b/packages/klevu-ui/src/components.d.ts
@@ -373,10 +373,6 @@ export namespace Components {
          */
         "option"?: KlevuFilterResultOptions;
         /**
-          * To set the facet selection value in the url
-         */
-        "shouldUpdateUrlForFacets"?: boolean;
-        /**
           * From which slider to build facet.
          */
         "slider"?: KlevuFilterResultSlider;
@@ -588,6 +584,10 @@ export namespace Components {
      */
     interface KlevuMerchandising {
         /**
+          * To update the pagination and filters to the url automatically
+         */
+        "autoUpdateUrl"?: boolean;
+        /**
           * Which category products
          */
         "category": string;
@@ -611,14 +611,6 @@ export namespace Components {
           * Object to override and settings on search options
          */
         "options"?: KlevuMerchandisingOptions;
-        /**
-          * To set the facet selection value in the url
-         */
-        "shouldUpdateUrlForFacets"?: boolean;
-        /**
-          * To set the page selection value in the url
-         */
-        "shouldUpdateUrlForPage"?: boolean;
         /**
           * Show ratings
          */
@@ -1437,6 +1429,10 @@ export namespace Components {
      */
     interface KlevuSearchLandingPage {
         /**
+          * To update the pagination and filters to the url automatically
+         */
+        "autoUpdateUrl"?: boolean;
+        /**
           * How many products to display in filters
          */
         "filterCount"?: number;
@@ -1464,14 +1460,6 @@ export namespace Components {
           * The factor to use to generate the ranges
          */
         "priceInterval": number;
-        /**
-          * To set the facet selection value in the url
-         */
-        "shouldUpdateUrlForFacets"?: boolean;
-        /**
-          * To set the page selection value in the url
-         */
-        "shouldUpdateUrlForPage"?: boolean;
         /**
           * Show price as options
          */
@@ -2851,10 +2839,6 @@ declare namespace LocalJSX {
          */
         "option"?: KlevuFilterResultOptions;
         /**
-          * To set the facet selection value in the url
-         */
-        "shouldUpdateUrlForFacets"?: boolean;
-        /**
           * From which slider to build facet.
          */
         "slider"?: KlevuFilterResultSlider;
@@ -3058,6 +3042,10 @@ declare namespace LocalJSX {
      */
     interface KlevuMerchandising {
         /**
+          * To update the pagination and filters to the url automatically
+         */
+        "autoUpdateUrl"?: boolean;
+        /**
           * Which category products
          */
         "category": string;
@@ -3082,14 +3070,6 @@ declare namespace LocalJSX {
           * Object to override and settings on search options
          */
         "options"?: KlevuMerchandisingOptions;
-        /**
-          * To set the facet selection value in the url
-         */
-        "shouldUpdateUrlForFacets"?: boolean;
-        /**
-          * To set the page selection value in the url
-         */
-        "shouldUpdateUrlForPage"?: boolean;
         /**
           * Show ratings
          */
@@ -3933,6 +3913,10 @@ declare namespace LocalJSX {
      */
     interface KlevuSearchLandingPage {
         /**
+          * To update the pagination and filters to the url automatically
+         */
+        "autoUpdateUrl"?: boolean;
+        /**
           * How many products to display in filters
          */
         "filterCount"?: number;
@@ -3961,14 +3945,6 @@ declare namespace LocalJSX {
           * The factor to use to generate the ranges
          */
         "priceInterval"?: number;
-        /**
-          * To set the facet selection value in the url
-         */
-        "shouldUpdateUrlForFacets"?: boolean;
-        /**
-          * To set the page selection value in the url
-         */
-        "shouldUpdateUrlForPage"?: boolean;
         /**
           * Show price as options
          */

--- a/packages/klevu-ui/src/components.d.ts
+++ b/packages/klevu-ui/src/components.d.ts
@@ -373,6 +373,10 @@ export namespace Components {
          */
         "option"?: KlevuFilterResultOptions;
         /**
+          * To set the facet selection value in the url
+         */
+        "shouldUpdateUrlForFacets"?: boolean;
+        /**
           * From which slider to build facet.
          */
         "slider"?: KlevuFilterResultSlider;
@@ -425,6 +429,10 @@ export namespace Components {
           * Set mode for facets or if object is passed then define per key
          */
         "mode"?: KlevuFacetMode1 | { [key: string]: KlevuFacetMode1 };
+        /**
+          * To set the facet selection value in the url
+         */
+        "shouldUpdateUrlForFacets"?: boolean;
         /**
           * When using `useApplyButton` then this method can be used to update current state filterManager into to local state of that is displayed in the UI
          */
@@ -604,6 +612,14 @@ export namespace Components {
          */
         "options"?: KlevuMerchandisingOptions;
         /**
+          * To set the facet selection value in the url
+         */
+        "shouldUpdateUrlForFacets"?: boolean;
+        /**
+          * To set the page selection value in the url
+         */
+        "shouldUpdateUrlForPage"?: boolean;
+        /**
           * Show ratings
          */
         "showRatings"?: boolean;
@@ -702,6 +718,10 @@ export namespace Components {
           * Query results used to build min, max and current
          */
         "queryResult"?: KlevuQueryResult;
+        /**
+          * To set the page selection value in the url
+         */
+        "shouldUpdateUrlForPage"?: boolean;
     }
     /**
      * Fetches and displays most popular searches from Klevu Merchant center
@@ -1444,6 +1464,14 @@ export namespace Components {
           * The factor to use to generate the ranges
          */
         "priceInterval": number;
+        /**
+          * To set the facet selection value in the url
+         */
+        "shouldUpdateUrlForFacets"?: boolean;
+        /**
+          * To set the page selection value in the url
+         */
+        "shouldUpdateUrlForPage"?: boolean;
         /**
           * Show price as options
          */
@@ -2823,6 +2851,10 @@ declare namespace LocalJSX {
          */
         "option"?: KlevuFilterResultOptions;
         /**
+          * To set the facet selection value in the url
+         */
+        "shouldUpdateUrlForFacets"?: boolean;
+        /**
           * From which slider to build facet.
          */
         "slider"?: KlevuFilterResultSlider;
@@ -2879,6 +2911,10 @@ declare namespace LocalJSX {
           * When filters are applied
          */
         "onKlevuApplyFilters"?: (event: KlevuFacetListCustomEvent<KlevuFiltersAppliedEventDetail>) => void;
+        /**
+          * To set the facet selection value in the url
+         */
+        "shouldUpdateUrlForFacets"?: boolean;
         /**
           * Display "apply filters" button in the end. And do not apply filters until this button is pressed
          */
@@ -3047,6 +3083,14 @@ declare namespace LocalJSX {
          */
         "options"?: KlevuMerchandisingOptions;
         /**
+          * To set the facet selection value in the url
+         */
+        "shouldUpdateUrlForFacets"?: boolean;
+        /**
+          * To set the page selection value in the url
+         */
+        "shouldUpdateUrlForPage"?: boolean;
+        /**
           * Show ratings
          */
         "showRatings"?: boolean;
@@ -3149,6 +3193,10 @@ declare namespace LocalJSX {
           * Query results used to build min, max and current
          */
         "queryResult"?: KlevuQueryResult;
+        /**
+          * To set the page selection value in the url
+         */
+        "shouldUpdateUrlForPage"?: boolean;
     }
     /**
      * Fetches and displays most popular searches from Klevu Merchant center
@@ -3913,6 +3961,14 @@ declare namespace LocalJSX {
           * The factor to use to generate the ranges
          */
         "priceInterval"?: number;
+        /**
+          * To set the facet selection value in the url
+         */
+        "shouldUpdateUrlForFacets"?: boolean;
+        /**
+          * To set the page selection value in the url
+         */
+        "shouldUpdateUrlForPage"?: boolean;
         /**
           * Show price as options
          */

--- a/packages/klevu-ui/src/components/klevu-facet-list/klevu-facet-list.tsx
+++ b/packages/klevu-ui/src/components/klevu-facet-list/klevu-facet-list.tsx
@@ -93,6 +93,12 @@ export class KlevuFacetList {
   @Prop() defaultPriceLabel = "Price"
 
   /**
+   * To set the facet selection value in the url
+   */
+  @Prop()
+  shouldUpdateUrlForFacets?: boolean
+
+  /**
    * When filters are applied
    */
   @Event({ composed: true })
@@ -114,6 +120,14 @@ export class KlevuFacetList {
     } else {
       this.filters = this.manager.filters
     }
+  }
+
+  componentWillLoad() {
+    const urlSearchParams = new URLSearchParams(window.location.search)
+    this.manager.readFromURLParams(urlSearchParams)
+    this.klevuApplyFilters.emit({
+      manager: this.manager,
+    })
   }
 
   @Listen("klevu-filters-applied", { target: "document" })
@@ -178,6 +192,7 @@ export class KlevuFacetList {
                 useColorSwatch={this.colorSwatches && !!this.colorSwatches.includes(f.key)}
                 colorSwatchOverrides={this.colorSwatchOverrides && this.colorSwatchOverrides[f.key]}
                 mode={mode}
+                shouldUpdateUrlForFacets={this.shouldUpdateUrlForFacets}
               ></klevu-facet>
             )
           } else if (FilterManager.isKlevuFilterResultSlider(f)) {
@@ -188,6 +203,7 @@ export class KlevuFacetList {
                 manager={this.useApplyButton ? this.#applyManager : this.manager}
                 slider={f}
                 labelOverride={f.label === "klevu_price" ? this.defaultPriceLabel : undefined}
+                shouldUpdateUrlForFacets={this.shouldUpdateUrlForFacets}
               ></klevu-facet>
             )
           }

--- a/packages/klevu-ui/src/components/klevu-facet-list/klevu-facet-list.tsx
+++ b/packages/klevu-ui/src/components/klevu-facet-list/klevu-facet-list.tsx
@@ -126,8 +126,7 @@ export class KlevuFacetList {
     if (!this.shouldUpdateUrlForFacets) {
       return
     }
-    const urlSearchParams = new URLSearchParams(window.location.search)
-    this.manager.readFromURLParams(urlSearchParams)
+    this.manager.readFromURLParams(new URL(document.URL).searchParams)
     this.klevuApplyFilters.emit({
       manager: this.manager,
     })
@@ -138,6 +137,10 @@ export class KlevuFacetList {
     this.#applyManager.setState(this.manager.getCurrentState())
     if (!this.useApplyButton) {
       this.filters = this.manager.filters
+    }
+    if (this.shouldUpdateUrlForFacets) {
+      const searchParams = this.manager.toURLParams(new URL(document.URL).searchParams)
+      window.history.replaceState({}, "", `${window.location.pathname}?${searchParams}`)
     }
   }
 
@@ -195,7 +198,6 @@ export class KlevuFacetList {
                 useColorSwatch={this.colorSwatches && !!this.colorSwatches.includes(f.key)}
                 colorSwatchOverrides={this.colorSwatchOverrides && this.colorSwatchOverrides[f.key]}
                 mode={mode}
-                shouldUpdateUrlForFacets={this.shouldUpdateUrlForFacets}
               ></klevu-facet>
             )
           } else if (FilterManager.isKlevuFilterResultSlider(f)) {
@@ -206,7 +208,6 @@ export class KlevuFacetList {
                 manager={this.useApplyButton ? this.#applyManager : this.manager}
                 slider={f}
                 labelOverride={f.label === "klevu_price" ? this.defaultPriceLabel : undefined}
-                shouldUpdateUrlForFacets={this.shouldUpdateUrlForFacets}
               ></klevu-facet>
             )
           }

--- a/packages/klevu-ui/src/components/klevu-facet-list/klevu-facet-list.tsx
+++ b/packages/klevu-ui/src/components/klevu-facet-list/klevu-facet-list.tsx
@@ -123,6 +123,9 @@ export class KlevuFacetList {
   }
 
   componentWillLoad() {
+    if (!this.shouldUpdateUrlForFacets) {
+      return
+    }
     const urlSearchParams = new URLSearchParams(window.location.search)
     this.manager.readFromURLParams(urlSearchParams)
     this.klevuApplyFilters.emit({

--- a/packages/klevu-ui/src/components/klevu-facet/klevu-facet.tsx
+++ b/packages/klevu-ui/src/components/klevu-facet/klevu-facet.tsx
@@ -121,6 +121,12 @@ export class KlevuFacet {
    */
   @Prop() colorSwatchOverrides?: KlevuColorSwatchOverride = {}
   /**
+   * To set the facet selection value in the url
+   */
+  @Prop()
+  shouldUpdateUrlForFacets?: boolean
+
+  /**
    * Show all options
    */
   @State() showAll = false
@@ -144,6 +150,18 @@ export class KlevuFacet {
       manager: this.manager,
       filter: event.detail,
     })
+    if (this.shouldUpdateUrlForFacets) {
+      this.#updateUrl()
+    }
+  }
+
+  #updateUrl = () => {
+    const filtersToParams = this.manager.toURLParams(window.location.search)
+    if (filtersToParams) {
+      if ("undefined" !== typeof window.history && "undefined" !== typeof window.history.replaceState) {
+        window.history.pushState({}, "", "?" + filtersToParams.toString())
+      }
+    }
   }
 
   async connectedCallback() {
@@ -161,7 +179,6 @@ export class KlevuFacet {
       this.settings = e.detail
     })
   }
-
   render() {
     return (
       <Host>

--- a/packages/klevu-ui/src/components/klevu-facet/klevu-facet.tsx
+++ b/packages/klevu-ui/src/components/klevu-facet/klevu-facet.tsx
@@ -120,11 +120,6 @@ export class KlevuFacet {
    * ImageUrl takes precedence over color when both are specified.
    */
   @Prop() colorSwatchOverrides?: KlevuColorSwatchOverride = {}
-  /**
-   * To set the facet selection value in the url
-   */
-  @Prop()
-  shouldUpdateUrlForFacets?: boolean
 
   /**
    * Show all options
@@ -150,18 +145,6 @@ export class KlevuFacet {
       manager: this.manager,
       filter: event.detail,
     })
-    if (this.shouldUpdateUrlForFacets) {
-      this.#updateUrl()
-    }
-  }
-
-  #updateUrl = () => {
-    const filtersToParams = this.manager.toURLParams(window.location.search)
-    if (filtersToParams) {
-      if ("undefined" !== typeof window.history && "undefined" !== typeof window.history.replaceState) {
-        window.history.pushState({}, "", "?" + filtersToParams.toString())
-      }
-    }
   }
 
   async connectedCallback() {
@@ -179,6 +162,7 @@ export class KlevuFacet {
       this.settings = e.detail
     })
   }
+
   render() {
     return (
       <Host>

--- a/packages/klevu-ui/src/components/klevu-merchandising/klevu-merchandising.stories.ts
+++ b/packages/klevu-ui/src/components/klevu-merchandising/klevu-merchandising.stories.ts
@@ -34,6 +34,7 @@ export const Merchandising: StoryObj<KlevuMerchandising> = {
     show-ratings-count=${ifDefined(args.showRatingsCount)}
     use-infinite-scroll=${ifDefined(args.useInfiniteScroll)}
     use-personalisation=${ifDefined(args.usePersonalisation)}
+    auto-update-url=${ifDefined(args.autoUpdateUrl)}
   ></klevu-merchandising>`,
 }
 

--- a/packages/klevu-ui/src/components/klevu-merchandising/klevu-merchandising.tsx
+++ b/packages/klevu-ui/src/components/klevu-merchandising/klevu-merchandising.tsx
@@ -123,6 +123,18 @@ export class KlevuMerchandising {
   usePersonalisation?: boolean
 
   /**
+   * To set the facet selection value in the url
+   */
+  @Prop()
+  shouldUpdateUrlForFacets?: boolean
+
+  /**
+   * To set the page selection value in the url
+   */
+  @Prop()
+  shouldUpdateUrlForPage?: boolean
+
+  /**
    * Overrides KMC setting to use ABtest for results
    */
   @Prop()
@@ -178,7 +190,7 @@ export class KlevuMerchandising {
       this.#resultObject = res.queriesById("categoryMerchandising")
       await this.#buildAfterResults()
     } else {
-      await this.#fetchData()
+      if (!this.shouldUpdateUrlForFacets) await this.#fetchData()
     }
   }
 
@@ -370,6 +382,7 @@ export class KlevuMerchandising {
                 useApplyButton={this.#isMobile()}
                 onKlevuApplyFilters={this.#applyFilters.bind(this)}
                 exportparts={partsExports("klevu-facet-list")}
+                shouldUpdateUrlForFacets={this.shouldUpdateUrlForFacets}
               ></klevu-facet-list>
             </div>
           </slot>
@@ -421,6 +434,7 @@ export class KlevuMerchandising {
                 exportparts={partsExports("klevu-pagination")}
                 queryResult={this.#resultObject}
                 onKlevuPaginationChange={this.#paginationChange.bind(this)}
+                shouldUpdateUrlForPage={this.shouldUpdateUrlForPage}
               ></klevu-pagination>
             ) : this.#resultObject?.hasNextPage() ? (
               <klevu-button onClick={this.#loadMore.bind(this)}>{this.tLoadMore}</klevu-button>

--- a/packages/klevu-ui/src/components/klevu-merchandising/klevu-merchandising.tsx
+++ b/packages/klevu-ui/src/components/klevu-merchandising/klevu-merchandising.tsx
@@ -123,16 +123,10 @@ export class KlevuMerchandising {
   usePersonalisation?: boolean
 
   /**
-   * To set the facet selection value in the url
+   * To update the pagination and filters to the url automatically
    */
   @Prop()
-  shouldUpdateUrlForFacets?: boolean
-
-  /**
-   * To set the page selection value in the url
-   */
-  @Prop()
-  shouldUpdateUrlForPage?: boolean
+  autoUpdateUrl?: boolean
 
   /**
    * Overrides KMC setting to use ABtest for results
@@ -190,7 +184,7 @@ export class KlevuMerchandising {
       this.#resultObject = res.queriesById("categoryMerchandising")
       await this.#buildAfterResults()
     } else {
-      if (!this.shouldUpdateUrlForFacets) await this.#fetchData()
+      await this.#fetchData()
     }
   }
 
@@ -382,7 +376,7 @@ export class KlevuMerchandising {
                 useApplyButton={this.#isMobile()}
                 onKlevuApplyFilters={this.#applyFilters.bind(this)}
                 exportparts={partsExports("klevu-facet-list")}
-                shouldUpdateUrlForFacets={this.shouldUpdateUrlForFacets}
+                shouldUpdateUrlForFacets={this.autoUpdateUrl}
               ></klevu-facet-list>
             </div>
           </slot>
@@ -434,7 +428,7 @@ export class KlevuMerchandising {
                 exportparts={partsExports("klevu-pagination")}
                 queryResult={this.#resultObject}
                 onKlevuPaginationChange={this.#paginationChange.bind(this)}
-                shouldUpdateUrlForPage={this.shouldUpdateUrlForPage}
+                shouldUpdateUrlForPage={this.autoUpdateUrl}
               ></klevu-pagination>
             ) : this.#resultObject?.hasNextPage() ? (
               <klevu-button onClick={this.#loadMore.bind(this)}>{this.tLoadMore}</klevu-button>

--- a/packages/klevu-ui/src/components/klevu-pagination/klevu-pagination.tsx
+++ b/packages/klevu-ui/src/components/klevu-pagination/klevu-pagination.tsx
@@ -75,12 +75,13 @@ export class KlevuPagination {
   }
 
   componentDidLoad() {
-    if (this.shouldUpdateUrlForPage) {
-      const urlSearchParams = new URLSearchParams(window.location.search)
-      const page = urlSearchParams.get("klevu_page")
-      if (page && +page > 0) {
-        this.klevuPaginationChange.emit(+page)
-      }
+    if (!this.shouldUpdateUrlForPage) {
+      return
+    }
+    const urlSearchParams = new URLSearchParams(window.location.search)
+    const page = urlSearchParams.get("klevu_page")
+    if (page && +page > 0) {
+      this.klevuPaginationChange.emit(+page)
     }
   }
 

--- a/packages/klevu-ui/src/components/klevu-pagination/klevu-pagination.tsx
+++ b/packages/klevu-ui/src/components/klevu-pagination/klevu-pagination.tsx
@@ -65,13 +65,7 @@ export class KlevuPagination {
   }
 
   #updateUrl(urlSearchParams: URLSearchParams) {
-    let paramsAsString = ""
-    for (const [key, value] of urlSearchParams.entries()) {
-      paramsAsString += `${paramsAsString ? "&" : ""}${key}=${encodeURIComponent(value)}`
-    }
-    if ("undefined" !== typeof window.history && "undefined" !== typeof window.history.replaceState) {
-      window.history.pushState({}, "", "?" + paramsAsString)
-    }
+    window.history.pushState({}, "", "?" + urlSearchParams.toString())
   }
 
   componentDidLoad() {

--- a/packages/klevu-ui/src/components/klevu-quicksearch/klevu-quicksearch.tsx
+++ b/packages/klevu-ui/src/components/klevu-quicksearch/klevu-quicksearch.tsx
@@ -10,7 +10,6 @@ import {
   KMCRootObject,
   KMCMapsRootObject,
   KlevuBanner,
-  KlevuUploadImageForSearch,
 } from "@klevu/core"
 import { Component, Fragment, h, Host, Listen, Prop, State, Event, EventEmitter, Watch } from "@stencil/core"
 import {

--- a/packages/klevu-ui/src/components/klevu-search-landing-page/klevu-search-landing-page.tsx
+++ b/packages/klevu-ui/src/components/klevu-search-landing-page/klevu-search-landing-page.tsx
@@ -13,7 +13,6 @@ import {
   KMCRootObject,
   trendingProducts,
   KlevuBanner,
-  KlevuUploadImageForSearch,
   klaviyo,
 } from "@klevu/core"
 import { Component, h, Host, Listen, Prop, State, Watch, Event, EventEmitter, Fragment } from "@stencil/core"
@@ -150,6 +149,18 @@ export class KlevuSearchLandingPage {
    */
   @Prop() showVariantsCount = false
 
+  /**
+   * To set the facet selection value in the url
+   */
+  @Prop()
+  shouldUpdateUrlForFacets?: boolean
+
+  /**
+   * To set the page selection value in the url
+   */
+  @Prop()
+  shouldUpdateUrlForPage?: boolean
+
   @State() results: Array<KlevuRecord> = []
   @State() manager = new FilterManager()
   @State() currentViewPortSize?: ViewportSize
@@ -216,7 +227,7 @@ export class KlevuSearchLandingPage {
   }
 
   async componentWillLoad() {
-    await this.#fetchData()
+    if (!this.shouldUpdateUrlForFacets) await this.#fetchData()
   }
 
   @Watch("term")
@@ -410,6 +421,7 @@ export class KlevuSearchLandingPage {
                   onKlevuApplyFilters={this.#applyFilters.bind(this)}
                   mode={facetMode}
                   exportparts={partsExports("klevu-facet-list")}
+                  shouldUpdateUrlForFacets={this.shouldUpdateUrlForFacets}
                 ></klevu-facet-list>
               )}
             </div>
@@ -458,7 +470,9 @@ export class KlevuSearchLandingPage {
                     <p class="noResultsMessage">
                       <klevu-typography variant="body-s">{this.noResultsMessage}</klevu-typography>
                     </p>
-                  ) : null}
+                  ) : (
+                    !this.loading && getTranslation("searchLandingPage.tNoResultsFound")
+                  )}
                   <Fragment>
                     <slot name="trending-products">
                       {this.trendingProducts.length > 0 && (
@@ -510,8 +524,9 @@ export class KlevuSearchLandingPage {
                 infiniteScrollPauseThreshold={3}
                 enabled={!!this.#resultObject?.hasNextPage() && !this.loading}
               ></klevu-util-infinite-scroll>
-            ) : this.usePagination && this.#resultObject ? (
+            ) : this.usePagination && this.#resultObject && this.results.length > 0 ? (
               <klevu-pagination
+                shouldUpdateUrlForPage={this.shouldUpdateUrlForPage}
                 exportparts={partsExports("klevu-pagination")}
                 queryResult={this.#resultObject}
                 onKlevuPaginationChange={this.paginationChange.bind(this)}

--- a/packages/klevu-ui/src/components/klevu-search-landing-page/klevu-search-landing-page.tsx
+++ b/packages/klevu-ui/src/components/klevu-search-landing-page/klevu-search-landing-page.tsx
@@ -150,16 +150,10 @@ export class KlevuSearchLandingPage {
   @Prop() showVariantsCount = false
 
   /**
-   * To set the facet selection value in the url
+   * To update the pagination and filters to the url automatically
    */
   @Prop()
-  shouldUpdateUrlForFacets?: boolean
-
-  /**
-   * To set the page selection value in the url
-   */
-  @Prop()
-  shouldUpdateUrlForPage?: boolean
+  autoUpdateUrl?: boolean
 
   @State() results: Array<KlevuRecord> = []
   @State() manager = new FilterManager()
@@ -227,7 +221,7 @@ export class KlevuSearchLandingPage {
   }
 
   async componentWillLoad() {
-    if (!this.shouldUpdateUrlForFacets) await this.#fetchData()
+    if (!this.autoUpdateUrl) await this.#fetchData()
   }
 
   @Watch("term")
@@ -421,7 +415,7 @@ export class KlevuSearchLandingPage {
                   onKlevuApplyFilters={this.#applyFilters.bind(this)}
                   mode={facetMode}
                   exportparts={partsExports("klevu-facet-list")}
-                  shouldUpdateUrlForFacets={this.shouldUpdateUrlForFacets}
+                  shouldUpdateUrlForFacets={this.autoUpdateUrl}
                 ></klevu-facet-list>
               )}
             </div>
@@ -526,7 +520,7 @@ export class KlevuSearchLandingPage {
               ></klevu-util-infinite-scroll>
             ) : this.usePagination && this.#resultObject && this.results.length > 0 ? (
               <klevu-pagination
-                shouldUpdateUrlForPage={this.shouldUpdateUrlForPage}
+                shouldUpdateUrlForPage={this.autoUpdateUrl}
                 exportparts={partsExports("klevu-pagination")}
                 queryResult={this.#resultObject}
                 onKlevuPaginationChange={this.paginationChange.bind(this)}


### PR DESCRIPTION
[CORE]
Added optional parameter to the `searchParams` to the `toUrlParams` function to allow initial value for conversion.
[UI]
Added support to allow saving facet selections and page numbers in url.
Added new attribute `autoUpdateUrl` to the klevu-merchandising and klevu-search-landing-page components to enable feature.
Added attributes to klevu-pagination and klevu-facet-list to enable feature at the component level.
