### PR TITLE
CORE: Remove duplicate ids from personalisation requests

### DIFF
--- a/packages/klevu-core/src/modifiers/personalisation/personalisation.ts
+++ b/packages/klevu-core/src/modifiers/personalisation/personalisation.ts
@@ -53,9 +53,10 @@ export function personalisation(options?: {
             category
           ).map((id) => ({ id }))
         } else {
-          records = KlevuLastClickedProducts.getLastClickedLatestsFirst().map(
-            (id) => ({ id })
-          )
+          records = KlevuLastClickedProducts.getLastClickedLatestsFirst(
+            10,
+            true
+          ).map((id) => ({ id }))
         }
 
         if (records.length > 0) {

--- a/packages/klevu-core/src/store/lastClickedProducts.test.ts
+++ b/packages/klevu-core/src/store/lastClickedProducts.test.ts
@@ -70,3 +70,27 @@ test("Disabled click tracking should return empty array", () => {
   expect(KlevuLastClickedProducts.getProducts(1).length).toBe(0)
   expect(KlevuLastClickedProducts.getLastClickedLatestsFirst(1).length).toBe(0)
 })
+
+test("Duplicates are filtered", () => {
+  KlevuConfig.getDefault().disableClickTracking = false
+
+  KlevuLastClickedProducts.click("5", {
+    id: "5",
+    name: "product 5",
+  } as KlevuRecord)
+
+  KlevuLastClickedProducts.click("5", {
+    id: "5",
+    name: "product 5",
+  } as KlevuRecord)
+
+  KlevuLastClickedProducts.click("5", {
+    id: "5",
+    name: "product 5",
+  } as KlevuRecord)
+
+  const lastClickedProducts =
+    KlevuLastClickedProducts.getLastClickedLatestsFirst(20, true)
+
+  expect(lastClickedProducts.filter((item) => item === "5").length).toBe(1)
+})

--- a/packages/klevu-core/src/store/lastClickedProducts.ts
+++ b/packages/klevu-core/src/store/lastClickedProducts.ts
@@ -82,15 +82,21 @@ class LastClickedProducts {
    * @param n
    * @returns
    */
-  getLastClickedLatestsFirst(n = 10): string[] {
+  getLastClickedLatestsFirst(n = 10, filterDuplicates = false): string[] {
     if (KlevuConfig.getDefault().disableClickTracking) {
       console.warn("Click tracking is disabled. Returning empty array.")
       return []
     }
 
-    return Array.from(this.clicks.map((i) => i.id))
-      .reverse()
-      .slice(0, n)
+    let clicks = Array.from(this.clicks.map((i) => i.id)).reverse()
+
+    if (filterDuplicates) {
+      clicks = clicks.filter(
+        (item, index, self) => index === self.findIndex((t) => t === item)
+      )
+    }
+
+    return clicks.slice(0, n)
   }
 
   /**
@@ -139,6 +145,9 @@ class LastClickedProducts {
     const itemsToTake = Math.floor(currentClicks.length / 3) * 3
     const ids = Array.from(currentClicks)
       .reverse()
+      .filter(
+        (item, index, self) => index === self.findIndex((t) => t.id === item.id)
+      )
       .slice(0, itemsToTake)
       .map((i) => i.id)
     this.categoryCache[categoryPath] = {


### PR DESCRIPTION
When using `personalisation` modifer we remove the duplicate ids from requests so that we can get more products to affect the personalisation.